### PR TITLE
Fix formatter output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Generated formatters
+formatters/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 tslint-bamboo-formatter is a Typescript library for creating JSON output files, which are used by Bamboo for logs.
 
+## Building
+If you want to generate formatter (e.g. `bambooFormatter.js`), use command below:
+
+```bash
+npx tsc
+```
+
 ## Installation
 
 Use the [npm](https://www.npmjs.com/package/tslint-bamboo-formatter) package manager to install tslint-bamboo-formatter.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "tslint-bamboo-formatter",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "description": "Custom formatter for bamboo and typescript files",
   "main": "formatters/bambooFormatter.js",
   "scripts": {
-	"prepublish": "tsc --build tsconfig.json",
+    "prepublish": "tsc --build tsconfig.json",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "tslint -c tslint.json -s formatters -t bamboo index.ts"
   },

--- a/src/bambooFormatter.ts
+++ b/src/bambooFormatter.ts
@@ -34,15 +34,24 @@ export class Formatter extends Lint.Formatters.AbstractFormatter {
 
 		const output: IOutputFile = {
 			stats: {
-				tests: 0,
-				passes: 0,
+				tests: 1 + errors.length, // watchdog + failures
+				passes: 1,
 				failures: errors.length,
 				duration: 0,
 				start: new global.Date(),
 				end: new global.Date(),
 			},
 			failures: [],
-			passes: [],
+			passes: [
+				{
+					// The underlying issue is that Bamboo expects the job to return a set of tests 
+					// that either pass or fail, but tslint outputs nothing if a file passes.
+					"title": "Watchdog",
+					"fullTitle": "Test that provides successful Mocha Test Parser execution",
+					"duration": 0,
+					"errorCount": 0
+				},
+			],
 			skipped: [],
 		};
 
@@ -65,18 +74,35 @@ export class Formatter extends Lint.Formatters.AbstractFormatter {
 			...memo,
 			...item.getFaltures.map((failure: Lint.RuleFailure) => {
 				const fileName = (failure.getFileName() || '').match('(?<=/)[^/]+$');
+				const filePath = path.resolve(failure.getFileName()).match("src/(.*)")[0];
+				const failurePosition = failure.getStartPosition().getPosition();
+				const lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
+				const positionTuple = `${lineAndCharacter.line + 1}:${lineAndCharacter.character + 1}`;
 
 				return ({
-					title: fileName ? fileName[0] : '',
-					fullTitle: path.resolve(failure.getFileName()),
+					// structure:
+					// TODO move to readme
+					// https://bitbucket.org/atlassian/bamboo-nodejs-plugin/src/bfde4b1a1931c11f3328206891b9bf3f0b0575fe/src/main/java/com/atlassian/bamboo/plugins/nodejs/tasks/mocha/parser/MochaSuiteTest.java?at=master#lines-9
+					// e.g. :
+					// 		"title": "getBackendLocalesOptions:707", // Must be uniq per error
+					//		"fullTitle": "semicolon",
+					// 		"duration": 0,
+					// 		"errorCount": 1,
+					// 		"error": "src/js/app/getBackendLocalesOptions.ts:24:19 - Missing semicolon"
+					// 
+					// Title requires split because of Bamboo-specific name parser, which cut it by dot
+					title: fileName ? fileName[0].split(".")[0] + ":" + failurePosition : '',
+					fullTitle: failure.getRuleName(),
 					duration: 0,
 					errorCount: 1,
-					error: failure.getFailure(),
+					error: `${filePath}:${positionTuple}` + " - " + failure.getFailure()
 				});
 			}),
 		]), []);
-
-		const stringifiedOutput = JSON.stringify(output);
+		
+		// We need prettified JSON output for correct parser results,
+		// so indent is set to 2.
+		const stringifiedOutput = JSON.stringify(output, null, 2);
 
 		this.writeFile(stringifiedOutput);
 
@@ -89,6 +115,6 @@ export class Formatter extends Lint.Formatters.AbstractFormatter {
 
 		fs.appendFileSync(outputFileName, file);
 
-		process.exit(0); // because formatters made by maintainer of tslint don't works as must to work
+		process.exit(0); // because formatters made by the maintainers of tslint don't work as they should.
 	}
 }


### PR DESCRIPTION
  * Added dummy test called `Watchdog`, because of
    parser requirements (at least 1 pased test)
  * Prettified json output
  * Improved `failure` fileds:
    * `error` - contains filepath and error line:pos
    * `fullTitle` - as a description field in Bamboo,
      contains mathced rule name
    * `title` - splitted by `.`, because of Bamboo
      parser specification

Listed improvements were successfully tested in prod Bamboo instance:
![image](https://user-images.githubusercontent.com/43776885/73411939-1e02d680-4318-11ea-945e-dc22a654b28f.png)
